### PR TITLE
(Minor) check-off query start state. Add .setup_assistant file

### DIFF
--- a/vs060_moveit_config/.setup_assistant
+++ b/vs060_moveit_config/.setup_assistant
@@ -1,0 +1,8 @@
+moveit_setup_assistant_config:
+  URDF:
+    package: vs060
+    relative_path: model/vs060A1_AV6_NNN_NNN.urdf
+  SRDF:
+    relative_path: config/vs060A1_AV6_NNN_NNN.srdf
+  CONFIG:
+    generated_timestamp: 1408435901

--- a/vs060_moveit_config/launch/moveit.rviz
+++ b/vs060_moveit_config/launch/moveit.rviz
@@ -113,7 +113,7 @@ Visualization Manager:
         Joint Violation Color: 255; 0; 255
         Planning Group: manipulator
         Query Goal State: true
-        Query Start State: true
+        Query Start State: false
         Show Workspace: false
         Start State Alpha: 1
         Start State Color: 0; 255; 0


### PR DESCRIPTION
I've seen many people (incl. me) who tried to move the arm by dragging the Interactive Marker of MoveIt!'s `Query Start State`. And I don't see many usecases in it.
