### PR TITLE
[Won't merge] Add ROS-I Cartesian Planner sample launch.

### DIFF
--- a/vs060_moveit_config/launch/demo_simulation_noenvironment_cartesianplanner.launch
+++ b/vs060_moveit_config/launch/demo_simulation_noenvironment_cartesianplanner.launch
@@ -1,0 +1,14 @@
+<launch>
+  <include file="$(find vs060_moveit_config)/launch/demo.launch">
+     <arg name="use_kinect" value="false" />
+     <arg name="use_rviz" value="false" />
+     <arg name="mode" value="simulation" />
+  </include>
+  <node name="rviz" pkg="rviz" type="rviz" respawn="true"
+	args="-d $(find vs060_moveit_config)/launch/moveit_cartesianplanner.rviz" output="screen">
+
+
+    <rosparam command="load" file="$(find vs060_moveit_config)/config/kinematics.yaml"/>
+  </node>
+
+</launch>

--- a/vs060_moveit_config/launch/moveit_cartesianplanner.rviz
+++ b/vs060_moveit_config/launch/moveit_cartesianplanner.rviz
@@ -1,0 +1,328 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /MotionPlanning1/Planning Request1
+        - /TF1/Frames1
+        - /TF1/Tree1
+        - /Axes1
+        - /InteractiveMarkers1
+      Splitter Ratio: 0.74256
+    Tree Height: 225
+  - Class: rviz/Help
+    Name: Help
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: moveit_cartesian_plan_plugin/MoveIt Cartesian Plan Plug-in
+    Name: MoveIt Cartesian Plan Plug-in
+    TextEntry: test_field
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.03
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: moveit_rviz_plugin/MotionPlanning
+      Enabled: true
+      MoveIt_Goal_Tolerance: 0
+      MoveIt_Planning_Time: 5
+      MoveIt_Use_Constraint_Aware_IK: true
+      MoveIt_Warehouse_Host: 127.0.0.1
+      MoveIt_Warehouse_Port: 33829
+      Name: MotionPlanning
+      Planned Path:
+        Links:
+          All Links Enabled: true
+          BASE:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Flange:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          J1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          J2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          J3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          J4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          J5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          Link Tree Style: Links in Alphabetic Order
+        Loop Animation: false
+        Robot Alpha: 0.4
+        Show Robot Collision: false
+        Show Robot Visual: true
+        Show Trail: false
+        State Display Time: 0.01s
+        Trajectory Topic: /move_group/display_planned_path
+      Planning Metrics:
+        Payload: 1
+        Show Joint Torques: false
+        Show Manipulability: false
+        Show Manipulability Index: false
+        Show Weight Limit: false
+        TextHeight: 0.08
+      Planning Request:
+        Colliding Link Color: 255; 0; 0
+        Goal State Alpha: 1
+        Goal State Color: 250; 128; 0
+        Interactive Marker Size: 0
+        Joint Violation Color: 255; 0; 255
+        Planning Group: manipulator
+        Query Goal State: true
+        Query Start State: true
+        Show Workspace: false
+        Start State Alpha: 1
+        Start State Color: 0; 255; 0
+      Planning Scene Topic: /move_group/monitored_planning_scene
+      Robot Description: robot_description
+      Scene Geometry:
+        Scene Alpha: 0.9
+        Scene Color: 50; 230; 50
+        Scene Display Time: 0.2
+        Show Scene Geometry: true
+        Voxel Coloring: Z-Axis
+        Voxel Rendering: Occupied Voxels
+      Scene Robot:
+        Attached Body Color: 150; 50; 150
+        Links:
+          All Links Enabled: true
+          BASE:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Flange:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          J1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          J2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          J3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          J4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          J5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          Link Tree Style: Links in Alphabetic Order
+        Robot Alpha: 0.5
+        Show Robot Collision: true
+        Show Robot Visual: true
+      Value: true
+    - Class: rviz/Camera
+      Enabled: true
+      Image Rendering: background and overlay
+      Image Topic: /camera/rgb/image_rect
+      Name: Camera
+      Overlay Alpha: 0.5
+      Queue Size: 2
+      Transport Hint: raw
+      Value: true
+      Visibility:
+        Axes: true
+        Grid: true
+        MotionPlanning: true
+        RobotModel: true
+        TF: true
+        Value: true
+      Zoom Factor: 1
+    - Class: rviz/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
+    - Class: rviz/Axes
+      Enabled: true
+      Length: 1
+      Name: Axes
+      Radius: 0.03
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        BASE:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Flange:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        J1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        J2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        J3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        J4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        J5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Link Tree Style: Links in Alphabetic Order
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/InteractiveMarkers
+      Enable Transparency: true
+      Enabled: true
+      Name: InteractiveMarkers
+      Show Axes: false
+      Show Descriptions: true
+      Show Visual Aids: false
+      Update Topic: /moveit_cartesian_planner/update
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: BASE
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+  Value: true
+  Views:
+    Current:
+      Class: rviz/XYOrbit
+      Distance: 2.25442
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.06
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.0321833
+        Y: -0.0823246
+        Z: 3.70813e-07
+      Name: Current View
+      Near Clip Distance: 0.01
+      Pitch: 0.4148
+      Target Frame: base_link
+      Value: XYOrbit (rviz)
+      Yaw: 1.05721
+    Saved: ~
+Window Geometry:
+  Cartesian Path Planner MoveIt Plug-in:
+    collapsed: false
+  Camera:
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 900
+  Help:
+    collapsed: false
+  Hide Left Dock: false
+  Hide Right Dock: false
+  Motion Planning:
+    collapsed: false
+  MoveIt Cartesian Plan Plug-in:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd0000000100000000000002a20000033efc0200000006fb0000001e004d006f00740069006f006e00200050006c0061006e006e0069006e00670100000028000001c80000017400fffffffb000000100044006900730070006c00610079007301000001f600000170000000dd00fffffffb0000000800480065006c00700000000342000000bb0000007600fffffffb0000000a0056006900650077007300000002d4000000b0000000b000fffffffb0000000c00430061006d00650072006100000002ff000001610000001600fffffffb0000000c00430061006d0065007200610100000266000001710000000000000000000002ef0000033e00000001000000020000000100000002fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Views:
+    collapsed: false
+  Width: 1431
+  X: 97
+  Y: 24

--- a/vs060_moveit_config/package.xml
+++ b/vs060_moveit_config/package.xml
@@ -26,6 +26,7 @@
   <run_depend>pr2_moveit_plugins</run_depend>
   <run_depend>robot_mechanism_controllers</run_depend>
   <run_depend>robot_state_publisher</run_depend>
+  <run_depend>moveit_cartesian_plan_plugin</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>


### PR DESCRIPTION
Adding .launch and .rviz files to utilize [moveit_cartesian_plan_plugin from ROS-Industrial](http://wiki.ros.org/moveit_cartesian_plan_plugin). 

Result looks like this video.
http://wiki.ros.org/denso?distro=hydro#denso_launch.Using_Cartesian_Path_Planner_Plug-In

From my experience, [moveit_cartesian_plan_plugin](https://github.com/ros-industrial-consortium/fermi) so far seems to require more development to become a standardized tool, e.g. with this PR RViz loses its window frame (it's also possible that my PR isn't sufficient, but then how to add `cartesian_plan_plugin` to your robot isn't documented AFAIK). That said, this PReq may stay un-merged, just remain as a reference purpose at least for now.
