### PR TITLE
do not show server:port for dryrun mode, and call ROS_FATAIL before exit(1)

### DIFF
--- a/denso_controller/src/main.cpp
+++ b/denso_controller/src/main.cpp
@@ -1289,14 +1289,20 @@ public:
       server_port_number_ = DEFAULT_SERVER_PORT_NUM;
     }
 
-    ROS_INFO("server: %s:%d", server_ip_address_.c_str(), server_port_number_);
+    if (!dryrunp_)
+    {
+      ROS_INFO("server: %s:%d", server_ip_address_.c_str(), server_port_number_);
+    }
 
     // Determine the pre-set UDP timeout length.
     if (!node.getParam("udp_timeout", udp_timeout_))
     {
       udp_timeout_ = DEFAULT_UDP_TIMEOUT;
     }
-    ROS_INFO("udp_timeout: %d micro sec", udp_timeout_);
+    if (!dryrunp_)
+    {
+      ROS_INFO("udp_timeout: %d micro sec", udp_timeout_);
+    }
   }
 
   void quitRequest()

--- a/denso_controller/src/main.cpp
+++ b/denso_controller/src/main.cpp
@@ -1188,26 +1188,55 @@ public:
       BCAP_HRESULT hr;
       ROS_INFO("bCapOpen");
       hr = bCapOpen();
-      if(FAILED(hr)) exit(1);
+      if(FAILED(hr))
+      {
+        ROS_FATAL("failed to open bCap socket. Exitting...");
+        ROS_FATAL("make sure that your robot is connected to %s:%d", server_ip_address_.c_str(), server_port_number_);
+        exit(1);
+      }
       setUDPTimeout(2, 0); // 2000msec
       ROS_INFO("bCapServerStart");
       hr = bCapServerStart();
-      if(FAILED(hr)) exit(1);
+      if(FAILED(hr))
+      {
+        ROS_FATAL("failed to start bCap server. Exitting...");
+        exit(1);
+      }
       ROS_INFO("bCapControllerConnect");
       hr = bCapControllerConnect();
-      if(FAILED(hr)) exit(1);
+      if(FAILED(hr))
+      {
+        ROS_FATAL("failed to connect bCap controller. Exitting...");
+        exit(1);
+      }
       ROS_INFO("bCapClearError");
       hr = bCapClearError();
-      if(FAILED(hr)) exit(1);
+      if(FAILED(hr))
+      {
+        ROS_FATAL("failed to clear bCap error. Exitting...");
+        exit(1);
+      }
       ROS_INFO("bCapGetRobot");
       hr = bCapGetRobot();
-      if(FAILED(hr)) exit(1);
+      if(FAILED(hr))
+      {
+        ROS_FATAL("failed to get bCap robot. Exitting...");
+        exit(1);
+      }
       ROS_INFO("bCapTakearm");
       hr = bCapTakearm();
-      if(FAILED(hr)) exit(1);
+      if(FAILED(hr))
+      {
+        ROS_FATAL("failed to take bCap arm. Exitting...");
+        exit(1);
+      }
       ROS_INFO("bCapSetExternalSpeed");
       hr = bCapSetExternalSpeed(100.0);
-      if(FAILED(hr)) exit(1);
+      if(FAILED(hr))
+      {
+        ROS_FATAL("failed to set external speed. Exitting...");
+        exit(1);
+      }
 
       bCapInitializeVariableHandlers();
 

--- a/denso_launch/launch/denso_vs060_moveit_demo_simulation.launch
+++ b/denso_launch/launch/denso_vs060_moveit_demo_simulation.launch
@@ -5,4 +5,6 @@
      <arg name="use_rviz" value="$(arg use_rviz)" />
      <arg name="mode" value="simulation" />
   </include>
+  <node pkg="vs060" type="publish_simple_scene.py"
+        name="publish_simple_scene" output="screen" />
 </launch>

--- a/denso_launch/launch/denso_vs060_moveit_demo_simulation.launch
+++ b/denso_launch/launch/denso_vs060_moveit_demo_simulation.launch
@@ -1,3 +1,8 @@
 <launch>
-  <include file="$(find vs060_moveit_config)/launch/demo_simulation_noenvironment.launch" />
+  <arg name="use_rviz" default="true" />
+  <include file="$(find vs060_moveit_config)/launch/demo.launch">
+     <arg name="use_kinect" value="false" />
+     <arg name="use_rviz" value="$(arg use_rviz)" />
+     <arg name="mode" value="simulation" />
+  </include>
 </launch>

--- a/denso_launch/test/denso_vs060_moveit_demo_test.py
+++ b/denso_launch/test/denso_vs060_moveit_demo_test.py
@@ -14,7 +14,7 @@ class TestDensoMoveit(unittest.TestCase):
         self.arm = MoveGroupCommander("manipulator")
 
     def test_moveit(self):
-        p = [ 0.35, -0.35, 0.4]
+        p = [ 0.1, -0.35, 0.4]
         pose = PoseStamped(header = rospy.Header(stamp = rospy.Time.now(), frame_id = '/BASE'),
                            pose = Pose(position = Point(*p),
                                        orientation = Quaternion(*quaternion_from_euler(1.57, 0, 1.57, 'sxyz'))))

--- a/denso_launch/test/test_moveit.py
+++ b/denso_launch/test/test_moveit.py
@@ -72,7 +72,7 @@ class TestMoveit(unittest.TestCase):
         pose_target.orientation.z = -0.20
         pose_target.orientation.w = 0.98
         pose_target.position.x = 0.18
-        pose_target.position.y = -0.00
+        pose_target.position.y = 0.18
         pose_target.position.z = 0.94
         return pose_target
 

--- a/denso_launch/test/vs060.test
+++ b/denso_launch/test/vs060.test
@@ -1,5 +1,5 @@
 <launch>
-  <include file="$(find vs060_moveit_config)/launch/demo_simulation_noenvironment.launch">
+  <include file="$(find denso_launch)/launch/denso_vs060_moveit_demo_simulation.launch">
      <arg name="use_rviz" value="false" />  <!-- RViz/GUI is not needed for the tests -->
   </include>
   

--- a/vs060/scripts/publish_simple_scene.py
+++ b/vs060/scripts/publish_simple_scene.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+
+from geometry_msgs.msg import PoseStamped
+from moveit_msgs.msg import PlanningScene, PlanningSceneComponents
+from moveit_msgs.srv import GetPlanningScene
+
+import rospy
+import moveit_commander
+
+# init rospy
+rospy.init_node("publish_simple_scene")
+
+# init moveit_commander
+moveit_commander.MoveGroupCommander('manipulator')
+scene_interface = moveit_commander.PlanningSceneInterface()
+# get_planning_scene
+try:
+    rospy.wait_for_service('/get_planning_scene', timeout=20);
+    get_planning_scene = rospy.ServiceProxy("/get_planning_scene", GetPlanningScene)
+except:
+    get_planning_scene = None
+
+# done
+rate = rospy.Rate(1)
+while not rospy.is_shutdown():
+    pose = PoseStamped()
+    pose.header.frame_id = 'BASE'
+    pose.pose.position.x = 0.3
+    pose.pose.position.y =-0.35
+    pose.pose.position.z = 0.5
+    pose.pose.orientation.w = 1.0
+    scene_interface.add_box('simple_object_1', pose, (0.2,0.5,0.04))
+    pose.pose.position.x = 0.3
+    pose.pose.position.y =-0.12
+    pose.pose.position.z = 0.72
+    scene_interface.add_box('simple_object_2', pose, (0.2,0.04,0.4))
+    pose.pose.position.x =-0.2
+    pose.pose.position.y = 0.0
+    pose.pose.position.z = 0.7
+    scene_interface.add_box('simple_object_3', pose, (0.04,1.0,0.2))
+    
+    rate.sleep()
+
+    if get_planning_scene and get_planning_scene(PlanningSceneComponents(components=PlanningSceneComponents.WORLD_OBJECT_NAMES)).scene.world.collision_objects != []:
+        break
+

--- a/vs060_moveit_config/config/vs060A1_AV6_NNN_NNN.srdf
+++ b/vs060_moveit_config/config/vs060A1_AV6_NNN_NNN.srdf
@@ -17,9 +17,6 @@
         <joint name="j5" />
         <joint name="flange" />
     </group>
-    <group name="manipulator_flange">
-        <joint name="flange" />
-    </group>
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
     <disable_collisions link1="BASE" link2="J1" reason="Adjacent" />
     <disable_collisions link1="BASE" link2="J2" reason="Never" />

--- a/vs060_moveit_config/launch/demo_simulation_noenvironment.launch
+++ b/vs060_moveit_config/launch/demo_simulation_noenvironment.launch
@@ -1,8 +1,0 @@
-<launch>
-  <arg name="use_rviz" default="true" />
-  <include file="$(find vs060_moveit_config)/launch/demo.launch">
-     <arg name="use_kinect" value="false" />
-     <arg name="use_rviz" value="$(arg use_rviz)" />
-     <arg name="mode" value="simulation" />
-  </include>
-</launch>

--- a/vs060_moveit_config/launch/move_group.launch
+++ b/vs060_moveit_config/launch/move_group.launch
@@ -45,6 +45,7 @@
 				      move_group/MoveGroupPlanService
 				      move_group/MoveGroupQueryPlannersService
 				      move_group/MoveGroupStateValidationService
+				      move_group/MoveGroupGetPlanningSceneService
 				      " />
 
     <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->


### PR DESCRIPTION
- call ROS_FATAL before exitting
- do not print server:,,, udp_timeout:... for dryrun mode
