### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/vs060A1_AV6_NNN_NNN_arm_navigation/src/vs060A1_AV6_NNN_NNN_manipulator_ikfast_plugin.cpp
+++ b/vs060A1_AV6_NNN_NNN_arm_navigation/src/vs060A1_AV6_NNN_NNN_manipulator_ikfast_plugin.cpp
@@ -987,5 +987,5 @@ namespace vs060A1_AV6_NNN_NNN_manipulator_kinematics
 } // end namespace
 
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(vs060A1_AV6_NNN_NNN_manipulator_kinematics, IKFastKinematicsPlugin, vs060A1_AV6_NNN_NNN_manipulator_kinematics::IKFastKinematicsPlugin, kinematics::KinematicsBase);
+PLUGINLIB_EXPORT_CLASS(vs060A1_AV6_NNN_NNN_manipulator_kinematics::IKFastKinematicsPlugin, kinematics::KinematicsBase);
 


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions