### PR TITLE
check CMake version rather than ROS version

### DIFF
--- a/vs060/CMakeLists.txt
+++ b/vs060/CMakeLists.txt
@@ -2,6 +2,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(vs060)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS roslang roscpp moveit_commander moveit_ros_planning)
 
 catkin_package(

--- a/vs060/CMakeLists.txt
+++ b/vs060/CMakeLists.txt
@@ -15,7 +15,7 @@ include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 add_executable(publish_scene_from_text src/publish_scene_from_text.cpp)
 target_link_libraries(publish_scene_from_text ${catkin_LIBRARIES})
-if ($ENV{ROS_DISTRO} STRGREATER "indigo")
+if (${CMAKE_VERSION} VERSION_GREATER "3.1.3")
   target_compile_features(publish_scene_from_text PRIVATE cxx_range_for)
 endif()
 


### PR DESCRIPTION
as `target_compile_features` is a CMake function, it seems more appropriate to check the CMake version rather than ROS distributions. In this case, `target_compile_features` requires CMake 3.1.3, but several platforms targeted by ROS Jade and Kinetic have an older version of CMake (Ubuntu Trusty and Debian Jessie for example). Example of failures without this patch on Debian Jessie [amd64](http://build.ros.org/view/Kbin_dj_dJ64/job/Kbin_dj_dJ64__vs060__debian_jessie_amd64__binary/245) and [arm64](http://build.ros.org/view/Kbin_djv8_dJv8/job/Kbin_djv8_dJv8__vs060__debian_jessie_arm64__binary/213/console).

Note that to get this package to compile on Debian Jessie, I also need to add `add_compile_options(-std=c++11)` to the CMake code as this package includes headers that use C++11 features (e.g. std::shared_ptr).